### PR TITLE
docs: add readmes for all tutorials

### DIFF
--- a/Libraries_for_robotics/README.md
+++ b/Libraries_for_robotics/README.md
@@ -1,0 +1,47 @@
+# Libraries for Robotics
+
+This folder contains small programs that verify the installation of common robotics libraries.
+
+## OMPL
+Run the provided test program to check the Open Motion Planning Library:
+```bash
+# Rebuild if needed
+# g++ ompl.cpp -o ompl $(pkg-config --cflags --libs ompl)
+./ompl
+```
+Expected output: `OMPL OK`.
+
+## PCL
+Test the Point Cloud Library:
+```bash
+# g++ pcl.cpp -o pcl $(pkg-config --cflags --libs pcl_common)
+./pcl
+```
+Expected output: `PCL OK`.
+
+## OpenCV
+`opencv.py` loads *humanoid_robot.jpeg*, converts it to grayscale and displays both images.
+```bash
+python opencv.py
+```
+Edit `image_path` in the script if the image is stored elsewhere.
+
+## PyTorch
+`pytorch.py` classifies *humanoid_robot.jpeg* with a pre‑trained ResNet‑18 model and prints the top label:
+```bash
+python pytorch.py
+```
+This requires PyTorch and torchvision.
+
+## CHAMP Integration Example
+`champ_libraries_integration` is a ROS 2 package combining OpenCV, PyTorch, PCL and OMPL in a single workspace.
+Build inside your ROS 2 workspace and run the nodes:
+```bash
+colcon build --packages-select champ_libraries_integration
+source install/setup.bash
+ros2 run champ_libraries_integration opencv_pytorch
+ros2 run champ_libraries_integration pcl_ompl
+```
+These nodes subscribe to camera or point‑cloud topics and demonstrate processing with the above libraries.
+
+What you learn: how to verify and combine popular robotics libraries within ROS 2 projects.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Repository for ROS2 Future Developers
-This repository is going to be a great support to every one learning ROS2 who needs scripts and explaination in the form of articles on *https://robotisim.com/* .Packges of ROS2 will be added here. Just clone it into your ros2_ws/src and perform colcon build.
-- Video Presentation -> **[[Channel link]](https://www.youtube.com/channel/UC-QzGbqufzwncwPQlOJfUXw)**
-## List of Packages:
-* [transforms Package Link](https://github.com/noshluk2/ros2_learners/tree/main/transforms) -> [Article Link](https://github.com/noshluk2/ros2_learners/tree/main/transforms)
+
+This collection accompanies the video tutorials on [RobotisIm](https://robotisim.com/) and the [YouTube channel](https://www.youtube.com/channel/UC-QzGbqufzwncwPQlOJfUXw).  Clone the repository into the `src` folder of your ROS 2 workspace and build the packages with `colcon`.
+
+## Directory Overview
+
+- [Libraries_for_robotics](Libraries_for_robotics/README.md) – small programs that verify and integrate common robotics libraries such as OMPL, PCL, OpenCV and PyTorch.
+- [ai_assitance](ai_assitance/README.md) – Python nodes for circular motion, obstacle avoidance and a Gazebo bringup.
+- [nodes](nodes/README.md) – C++ examples of publishers, subscribers, laser scans and launch files.
+- [resources](resources/README.md) – quick reference command snippets.
+- [transforms](transforms/README.md) – `tf2` tutorials with RViz and Gazebo visualisation.
+- [navigation_tb3](navigation_tb3/README.md) – TurtleBot3 navigation demos using Nav2.
+- [point_cloud_perception](point_cloud_perception/README.md) – PCL based point‑cloud processing and RTAB‑Map launches.
+- [robot_math](robot_math/README.md) – turtlesim exercises demonstrating angular velocity and go‑to‑goal control.
+- [turtlebot3_gazebo](turtlebot3_gazebo/README.md) – simulation assets and launch files for TurtleBot3 in Gazebo.
+
+Each directory contains its own README with instructions on how to run the examples and what concepts they teach.

--- a/ai_assitance/README.md
+++ b/ai_assitance/README.md
@@ -1,0 +1,29 @@
+# AI Assistance
+
+ROS 2 Python package providing simple motion behaviours and a Gazebo bringup.
+
+## Building
+Add this package to your ROS 2 workspace and build:
+```bash
+colcon build --packages-select ai_assitance
+source install/setup.bash
+```
+
+## Nodes
+- `my_circle_movement` – publishes velocity commands that drive a robot in a circle.
+  ```bash
+  ros2 run ai_assitance my_circle_movement
+  ```
+- `obstacle_avoiding_node` – subscribes to `/scan` and steers away when obstacles are closer than 0.5 m.
+  ```bash
+  ros2 run ai_assitance obstacle_avoiding_node
+  ```
+
+## Gazebo Launch
+Spawn the sample `dolly` robot in Gazebo:
+```bash
+ros2 launch ai_assitance gazebo_bringup.launch.py
+```
+This launch file runs the state publishers and uses `gazebo_ros` to spawn the URDF model.
+
+What you'll learn: writing basic ROS 2 nodes, publishing velocity commands and launching a robot model in simulation.

--- a/navigation_tb3/README.md
+++ b/navigation_tb3/README.md
@@ -1,0 +1,20 @@
+# Navigation TB3
+
+TurtleBot3 navigation demos using the Nav2 stack.
+
+## Building
+```bash
+colcon build --packages-select navigation_tb3
+source install/setup.bash
+```
+
+## Launch
+- `ros2 launch navigation_tb3 mapping.launch.py` – start SLAM mapping and generate `tb3_map`.
+- `ros2 launch navigation_tb3 navigation.launch.py` – bring up Nav2 using the provided map and parameters.
+
+## Nodes and Scripts
+- `ros2 run navigation_tb3 pub_occupancy_grid` – publish an occupancy grid from `config/tb3_map.yaml`.
+- `ros2 run navigation_tb3 single_goal_nav` – send a single goal pose using `nav2_simple_commander`.
+- `ros2 run navigation_tb3 multi_waypoints` – patrol a list of waypoints.
+
+What you'll learn: configuring Nav2 for TurtleBot3, mapping an environment and commanding navigation goals from Python.

--- a/nodes/README.md
+++ b/nodes/README.md
@@ -1,0 +1,29 @@
+# Nodes
+
+C++ examples demonstrating core ROS 2 concepts: publishers, subscribers, timers and launch files.
+
+## Building
+```bash
+colcon build --packages-select nodes
+source install/setup.bash
+```
+
+## Publisher and Subscriber
+Start the basic talker and listener:
+```bash
+ros2 run nodes publisher
+ros2 run nodes subscriber
+```
+The publisher sends messages on `topic_1` and `topic_2`; the subscriber logs the received strings and integers.
+
+## Laser Scan Publisher
+```bash
+ros2 run nodes laser_publisher
+```
+Publishes a synthetic `sensor_msgs/LaserScan` on `/scan`.
+
+## Launch Examples
+- `ros2 launch nodes nodes.launch.py` – runs two `turtlesim` nodes and mirrors motion using the `mimic` node.
+- `ros2 launch nodes map_launch.py` – starts a `nav2_map_server` using the images in `maps/`.
+
+What you'll learn: building and launching simple ROS 2 nodes and publishing custom messages.

--- a/point_cloud_perception/README.md
+++ b/point_cloud_perception/README.md
@@ -1,0 +1,26 @@
+# Point Cloud Perception
+
+Point Cloud Library (PCL) examples for filtering, segmentation and mapping.
+
+## Building
+```bash
+colcon build --packages-select point_cloud_perception
+source install/setup.bash
+```
+
+## Executables
+Run the compiled demos:
+```bash
+ros2 run point_cloud_perception voxeling       # voxel grid downsampling
+ros2 run point_cloud_perception planner_seg    # plane segmentation
+ros2 run point_cloud_perception clustering     # cylinder extraction
+```
+`clustering` expects a PCD file in `point_clouds/` and writes extracted clouds back to the same directory.
+
+## Launch Files
+- `ros2 launch point_cloud_perception 3d_depth_mapping_rtab.launch.py`
+- `ros2 launch point_cloud_perception rtab_mapping.launch.py`
+
+These launches start RTAB‑Map for 3D mapping and depth processing.
+
+What you'll learn: how to process point clouds in ROS 2 using PCL and integrate them with mapping tools.

--- a/resources/README.md
+++ b/resources/README.md
@@ -1,0 +1,7 @@
+# Resources
+
+Miscellaneous reference material used in the tutorials.
+
+- [commands.md](commands.md) – handy ROS 2 command‑line snippets for creating packages, inspecting interfaces and locating headers.
+
+What you'll learn: quick access to common commands while working through the lessons.

--- a/robot_math/README.md
+++ b/robot_math/README.md
@@ -1,0 +1,27 @@
+# Robot Math
+
+ROS 2 package showcasing basic control equations with `turtlesim`.
+
+## Building
+```bash
+colcon build --packages-select robot_math
+source install/setup.bash
+```
+Ensure `turtlesim` is running in another terminal:
+```bash
+ros2 run turtlesim turtlesim_node
+```
+
+## Nodes
+- `circle_motion_node` – drives a circular path based on linear velocity and radius:
+  ```bash
+  ros2 run robot_math circle_motion_node <linear_vel> <radius>
+  ```
+- `go_To_Goal_node` – moves the turtle toward a specified goal pose:
+  ```bash
+  ros2 run robot_math go_To_Goal_node <x> <y> <theta>
+  ```
+
+Both nodes publish to `/turtle1/cmd_vel` and demonstrate angular velocity and go‑to‑goal control.
+
+What you'll learn: applying mathematical formulas to control a robot in ROS 2.

--- a/transforms/README.md
+++ b/transforms/README.md
@@ -1,0 +1,25 @@
+# Transforms
+
+Examples demonstrating `tf2` frame manipulation and robot model visualisation.
+
+## Building
+```bash
+colcon build --packages-select transforms
+source install/setup.bash
+```
+
+## Nodes
+Run any of the C++ examples to broadcast different transform scenarios:
+```bash
+ros2 run transforms translation_frame
+ros2 run transforms rotation_frame
+ros2 run transforms transform_order
+ros2 run transforms frame_chains
+ros2 run transforms static_dynamic_frame
+```
+
+## Launch Files
+- `ros2 launch transforms rviz.launch.py` – loads `urdf/diff_drive.urdf` into RViz using the configuration in `config/`.
+- `ros2 launch transforms gazebo.launch.py` – spawns the same robot model in Gazebo for simulation.
+
+What you'll learn: creating static and dynamic frames, chaining transforms and visualising URDF models.

--- a/turtlebot3_gazebo/README.md
+++ b/turtlebot3_gazebo/README.md
@@ -1,48 +1,15 @@
-# TurtleBot3
-<img src="https://github.com/ROBOTIS-GIT/emanual/blob/master/assets/images/platform/turtlebot3/logo_turtlebot3.png" width="300">
+# TurtleBot3 Gazebo
 
-[![kinetic-devel Status](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/workflows/kinetic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/tree/kinetic-devel)
-[![melodic-devel Status](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/workflows/melodic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/tree/melodic-devel)
-[![noetic-devel Status](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/workflows/noetic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/tree/noetic-devel)
+Gazebo simulation assets for the TurtleBot3 robot.
 
-[![dashing-devel Status](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/workflows/dashing-devel/badge.svg)](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/tree/dashing-devel)
-[![foxy-devel Status](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/workflows/foxy-devel/badge.svg)](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/tree/foxy-devel)
-[![galactic-devel Status](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/workflows/galactic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/tree/galactic-devel)
-[![humble-devel Status](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/workflows/humble-devel/badge.svg)](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/tree/humble-devel)
+## Running the Simulation
+Launch the default world with a single TurtleBot3:
+```bash
+ros2 launch turtlebot3_gazebo turtlebot3_world.launch.py
+```
+Other launch files in the `launch/` directory provide additional worlds such as `turtlebot3_house.launch.py` or allow spawning into an existing Gazebo instance.
 
-## ROBOTIS e-Manual for TurtleBot3
-- [ROBOTIS e-Manual for TurtleBot3](http://turtlebot3.robotis.com/)
+## Resources
+Documentation and tutorials for TurtleBot3 are available from [ROBOTIS](http://turtlebot3.robotis.com/) and the [turtlebot3_simulations](https://github.com/ROBOTIS-GIT/turtlebot3_simulations) repository, on which this package is based.
 
-## Wiki for turtlebot3_simulations Packages
-- http://wiki.ros.org/turtlebot3_simulations (metapackage)
-- http://wiki.ros.org/turtlebot3_fake
-- http://wiki.ros.org/turtlebot3_gazebo
-
-## Open Source related to TurtleBot3
-- [turtlebot3](https://github.com/ROBOTIS-GIT/turtlebot3)
-- [turtlebot3_msgs](https://github.com/ROBOTIS-GIT/turtlebot3_msgs)
-- [turtlebot3_simulations](https://github.com/ROBOTIS-GIT/turtlebot3_simulations)
-- [turtlebot3_applications_msgs](https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs)
-- [turtlebot3_applications](https://github.com/ROBOTIS-GIT/turtlebot3_applications)
-- [turtlebot3_autorace](https://github.com/ROBOTIS-GIT/turtlebot3_autorace)
-- [turtlebot3_deliver](https://github.com/ROBOTIS-GIT/turtlebot3_deliver)
-- [hls_lfcd_lds_driver](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver)
-- [ld08_driver](https://github.com/ROBOTIS-GIT/ld08_driver)
-- [open_manipulator_msgs](https://github.com/ROBOTIS-GIT/open_manipulator_msgs)
-- [open_manipulator](https://github.com/ROBOTIS-GIT/open_manipulator)
-- [open_manipulator_simulations](https://github.com/ROBOTIS-GIT/open_manipulator_simulations)
-- [open_manipulator_perceptions](https://github.com/ROBOTIS-GIT/open_manipulator_perceptions)
-- [open_manipulator_with_tb3_msgs](https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs)
-- [open_manipulator_with_tb3](https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3)
-- [open_manipulator_with_tb3_simulations](https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_simulations)
-- [dynamixel_sdk](https://github.com/ROBOTIS-GIT/DynamixelSDK)
-- [OpenCR-Hardware](https://github.com/ROBOTIS-GIT/OpenCR-Hardware)
-- [OpenCR](https://github.com/ROBOTIS-GIT/OpenCR)
-
-## Documents and Videos related to TurtleBot3
-- [ROBOTIS e-Manual for TurtleBot3](http://turtlebot3.robotis.com/)
-- [ROBOTIS e-Manual for OpenManipulator](http://emanual.robotis.com/docs/en/platform/openmanipulator/)
-- [ROBOTIS e-Manual for Dynamixel SDK](http://emanual.robotis.com/docs/en/software/dynamixel/dynamixel_sdk/overview/)
-- [Website for TurtleBot Series](http://www.turtlebot.com/)
-- [e-Book for TurtleBot3](https://community.robotsource.org/t/download-the-ros-robot-programming-book-for-free/51/)
-- [Videos for TurtleBot3 ](https://www.youtube.com/playlist?list=PLRG6WP3c31_XI3wlvHlx2Mp8BYqgqDURU)
+What you'll learn: running the TurtleBot3 robot in Gazebo for experimentation and testing.


### PR DESCRIPTION
## Summary
- add README files for each tutorial directory with run instructions and learning goals
- streamline top-level README with links to all packages
- simplify TurtleBot3 Gazebo README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'ament_copyright')*

------
https://chatgpt.com/codex/tasks/task_e_68a7188d079483268198d46f589d27b5